### PR TITLE
Reworked plan generation to go through optimizer.

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/StatementContext.java
@@ -85,7 +85,10 @@ public class StatementContext {
     private boolean isClientSideUpsertSelect;
     private boolean isUncoveredIndex;
     private String cdcIncludeScopes;
-    
+    private TableRef cdcTableRef;
+    private QueryPlan cdcDataPlan;
+    private TableRef cdcDataTableRef;
+
     public StatementContext(PhoenixStatement statement) {
         this(statement, new Scan());
     }
@@ -386,4 +389,28 @@ public class StatementContext {
     public void setCDCIncludeScopes(Set<PTable.CDCChangeScope> cdcIncludeScopes) {
         this.cdcIncludeScopes = CDCUtil.makeChangeScopeStringFromEnums(cdcIncludeScopes);
     }
+
+    public TableRef getCDCDataTableRef() {
+        return cdcDataTableRef;
+    }
+
+    public void setCDCDataTableRef(TableRef cdcDataTableRef) {
+        this.cdcDataTableRef = cdcDataTableRef;
+    }
+
+    public TableRef getCDCTableRef() {
+        return cdcTableRef;
+    }
+
+    public void setCDCTableRef(TableRef cdcTableRef) {
+        this.cdcTableRef = cdcTableRef;
+    }
+
+    //public QueryPlan getCDCDataPlan() {
+    //    return cdcDataPlan;
+    //}
+
+    //public void setCDCDataPlan(QueryPlan cdcDataPlan) {
+    //    this.cdcDataPlan = cdcDataPlan;
+    //}
 }

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/BaseScannerRegionObserver.java
@@ -150,7 +150,6 @@ abstract public class BaseScannerRegionObserver implements RegionObserver {
     public static final String EMPTY_COLUMN_QUALIFIER_NAME = "_EmptyCQName";
     public static final String INDEX_ROW_KEY = "_IndexRowKey";
     public static final String READ_REPAIR_TRANSFORMING_TABLE = "_ReadRepairTransformingTable";
-    public static final String CDC_DATA_TABLE_NAME = "_CdcDataTableName";
     public static final String CDC_JSON_COL_QUALIFIER = "_CdcJsonColumn_Qualifier";
     public static final String CDC_INCLUDE_SCOPES = "_CdcIncludeScopes";
     public static final String CDC_DATA_TABLE_DEF = "_CdcDataTableDef";

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/CDCGlobalIndexRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/CDCGlobalIndexRegionScanner.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_DATA_TABLE_DEF;
-import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_INCLUDE_SCOPES;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_JSON_COL_QUALIFIER;
 import static org.apache.phoenix.query.QueryConstants.CDC_DELETE_EVENT_TYPE;
 import static org.apache.phoenix.query.QueryConstants.CDC_EVENT_TYPE;

--- a/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/coprocessor/UncoveredIndexRegionScanner.java
@@ -59,8 +59,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_DATA_TABLE_NAME;
-import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_JSON_COL_QUALIFIER;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EMPTY_COLUMN_FAMILY_NAME;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EMPTY_COLUMN_QUALIFIER_NAME;
 import static org.apache.phoenix.query.QueryConstants.VALUE_COLUMN_FAMILY;

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/BaseResultIterators.java
@@ -963,6 +963,10 @@ public abstract class BaseResultIterators extends ExplainTable implements Result
         byte[] stopRegionBoundaryKey = stopKey;
         int columnsInCommon = 0;
         ScanRanges prefixScanRanges = ScanRanges.EVERYTHING;
+        if (table.getTableName().getString().equals("N000002") ||
+                   table.getTableName().getString().equals("__CDC__N000002")) {
+            "".isEmpty();
+        }
         boolean traverseAllRegions = isSalted || isLocalIndex;
         if (isLocalIndex) {
             // TODO: when implementing PHOENIX-4585, we should change this to an assert

--- a/phoenix-core/src/main/java/org/apache/phoenix/iterate/RegionScannerFactory.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/iterate/RegionScannerFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.phoenix.iterate;
 
-import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_DATA_TABLE_NAME;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.CDC_DATA_TABLE_DEF;
 import static org.apache.phoenix.coprocessor.ScanRegionObserver.WILDCARD_SCAN_INCLUDES_DYNAMIC_COLUMNS;
 import static org.apache.phoenix.schema.types.PDataType.TRUE_BYTES;
 
@@ -191,7 +191,7 @@ public abstract class RegionScannerFactory {
                               dataTableScan, tupleProjector, indexMaintainer, viewConstants, ptr,
                               pageSizeMs, offset, actualStartKey, extraLimit);
                   } else {
-                      if (scan.getAttribute(CDC_DATA_TABLE_NAME) != null) {
+                      if (scan.getAttribute(CDC_DATA_TABLE_DEF) != null) {
                           s = new CDCGlobalIndexRegionScanner(regionScanner, dataRegion, scan, env,
                                   dataTableScan, tupleProjector, indexMaintainer, viewConstants, ptr,
                                   pageSizeMs, extraLimit);

--- a/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/query/ConnectionQueryServicesImpl.java
@@ -776,7 +776,9 @@ public class ConnectionQueryServicesImpl extends DelegateQueryServices implement
                 } while (!Bytes.equals(currentKey, HConstants.EMPTY_END_ROW));
                 return locations;
             } catch (org.apache.hadoop.hbase.TableNotFoundException e) {
-                throw new TableNotFoundException(table.getNameAsString());
+                TableNotFoundException ex = new TableNotFoundException(table.getNameAsString());
+                e.initCause(ex);
+                throw ex;
             } catch (IOException e) {
                 LOGGER.error("Exception encountered in getAllTableRegions for "
                         + "table: {}, retryCount: {}", table.getNameAsString(), retryCount, e);

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/PTableImpl.java
@@ -1795,9 +1795,7 @@ public class PTableImpl implements PTable {
                 return SchemaUtil.getPhysicalHBaseTableName(schemaName,
                         physicalTableNameColumnInSyscat, isNamespaceMapped);
             }
-            return SchemaUtil.getPhysicalHBaseTableName(schemaName, getType() == PTableType.CDC ?
-                    PNameFactory.newName(CDCUtil.getCDCIndexName(tableName.getString())) :
-                    tableName, isNamespaceMapped);
+            return SchemaUtil.getPhysicalHBaseTableName(schemaName, tableName, isNamespaceMapped);
         } else {
             return PNameFactory.newName(physicalNames.get(0).getBytes());
         }
@@ -2194,6 +2192,10 @@ public class PTableImpl implements PTable {
         }
         if (table.getViewStatement() != null) {
             builder.setViewStatement(ByteStringer.wrap(PVarchar.INSTANCE.toBytes(table.getViewStatement())));
+        }
+        if (table.getTableName().getString().equals("N000002") ||
+                table.getTableName().getString().equals("N000003")) {
+            "".isEmpty();
         }
         for (int i = 0; i < table.getPhysicalNames().size(); i++) {
             builder.addPhysicalNames(ByteStringer.wrap(table.getPhysicalNames().get(i).getBytes()));

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/SaltingUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/SaltingUtil.java
@@ -41,9 +41,6 @@ public class SaltingUtil {
     public static final PColumnImpl SALTING_COLUMN = new PColumnImpl(
             PNameFactory.newName(SALTING_COLUMN_NAME), null, PBinary.INSTANCE, 1, 0, false, 0, SortOrder.getDefault(), 0, null, false, null, false, false, null,
         HConstants.LATEST_TIMESTAMP);
-    public static final RowKeySchema VAR_BINARY_SALTED_SCHEMA = new RowKeySchemaBuilder(2)
-        .addField(SALTING_COLUMN, false, SortOrder.getDefault())
-        .addField(SchemaUtil.VAR_BINARY_DATUM, false, SortOrder.getDefault()).build();
 
     public static List<KeyRange> generateAllSaltingRanges(int bucketNum) {
         List<KeyRange> allRanges = Lists.newArrayListWithExpectedSize(bucketNum);

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/CDCUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/CDCUtil.java
@@ -25,6 +25,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.phoenix.exception.SQLExceptionCode;


### PR DESCRIPTION
This change removes the PHOENIX_ROW_TIMESTAMP() column from CDC schema and manipulates the PTableImpl objects of CDC and index to satisfy the the regular optimizer code path which addresses the following issues:
* Time range queries are not setting starRow/endRow scan attributes
* CDC on top of views is not working
* CDC on multitenant tables is not working.

There are still the following issues to deal with:
* PHOENIX_ROW_TIMESTAMP() is now missing, it needs to be added dynamically for wildcard queries or needs to be included in the CDC JSON.
* There is a change in the row order issue and it is causing sotSelectCDCWithDDL and testSelectCDC tests to fail.
* With salting, other than the above 2 tests that are failing due to some ordering issues, there is no data coming in for testSelectTimeRangeQueries.