### PR TITLE
Cdc fix index salting

### DIFF
--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
@@ -1,5 +1,6 @@
 package org.apache.phoenix.end2end;
 
+import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.PIndexState;
 import org.apache.phoenix.schema.PTable;
@@ -114,7 +115,7 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
 
     protected Connection newConnection(String tenantId) throws SQLException {
         Properties props = new Properties();
-        // FIXME: Uncomment these only while debugging.
+        // Uncomment these only while debugging.
         //props.put(QueryServices.TASK_HANDLING_INTERVAL_MS_ATTRIB, Long.toString(Long.MAX_VALUE));
         //props.put("hbase.client.scanner.timeout.period", "6000000");
         //props.put("phoenix.query.timeoutMs", "6000000");

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
@@ -13,6 +13,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -20,23 +21,25 @@ import java.util.Set;
 
 import static org.apache.phoenix.util.MetaDataUtil.getViewIndexPhysicalName;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 public class CDCBaseIT extends ParallelStatsDisabledIT {
     protected void createTable(Connection conn, String table_sql,
                                PTable.QualifierEncodingScheme encodingScheme)
             throws Exception {
-        createTable(conn, table_sql, encodingScheme, false, 0);
+        createTable(conn, table_sql, encodingScheme, false, null);
     }
 
     protected void createTable(Connection conn, String table_sql,
                                PTable.QualifierEncodingScheme encodingScheme, boolean multitenant)
             throws Exception {
-        createTable(conn, table_sql, encodingScheme, multitenant, 0);
+        createTable(conn, table_sql, encodingScheme, multitenant, null);
     }
 
     protected void createTable(Connection conn, String table_sql,
-                               PTable.QualifierEncodingScheme encodingScheme, boolean multitenant, int nSaltBuckets)
+                               PTable.QualifierEncodingScheme encodingScheme, boolean multitenant,
+                               Integer nSaltBuckets)
             throws Exception {
         List<String> props = new ArrayList<>();
         if (encodingScheme != null && encodingScheme.getSerializedMetadataValue() !=
@@ -47,10 +50,11 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
         if (multitenant) {
             props.add("MULTI_TENANT=true");
         }
-        if (nSaltBuckets != 0) {
+        if (nSaltBuckets != null) {
             props.add("SALT_BUCKETS=" + nSaltBuckets);
         }
-        conn.createStatement().execute(table_sql + " " + String.join(", ", props));
+        table_sql = table_sql + " " + String.join(", ", props);
+        conn.createStatement().execute(table_sql);
     }
 
     protected void createCDCAndWait(Connection conn, String schemaName, String tableName, String cdcName,
@@ -60,7 +64,7 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
 
     protected void createCDCAndWait(Connection conn, String schemaName, String tableName, String cdcName,
                                     String cdc_sql, PTable.QualifierEncodingScheme encodingScheme,
-                                    int nSaltBuckets) throws Exception {
+                                    Integer nSaltBuckets) throws Exception {
         // For CDC, multitenancy gets derived automatically via the parent table.
         createTable(conn, cdc_sql, encodingScheme, false, nSaltBuckets);
         IndexToolIT.runIndexTool(false, schemaName, tableName,
@@ -100,13 +104,33 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
                         getViewIndexPhysicalName(datatableName));
     }
 
-    protected void assertSaltBuckets(String cdcName, Integer nbuckets) throws SQLException {
+    protected void assertCDCSaltBuckets(String cdcName, Integer nbuckets) throws SQLException {
         Properties props = new Properties();
         Connection conn = DriverManager.getConnection(getUrl(), props);
         PTable cdcTable = PhoenixRuntime.getTable(conn, cdcName);
-        assertNull(cdcTable.getBucketNum());
-        PTable indexTable = PhoenixRuntime.getTable(conn, CDCUtil.getCDCIndexName(cdcName));
-        assertEquals(nbuckets, indexTable.getBucketNum());
+        assertSaltBuckets(cdcTable, nbuckets);
+        assertSaltBuckets(conn, CDCUtil.getCDCIndexName(cdcName), nbuckets);
+    }
+
+    protected void assertSaltBuckets(Connection conn, String tableName, Integer nbuckets)
+            throws SQLException {
+        PTable table = PhoenixRuntime.getTable(conn, tableName);
+        assertSaltBuckets(table, nbuckets);
+    }
+
+    protected void assertSaltBuckets(PTable table, Integer nbuckets) {
+        if (nbuckets == null || nbuckets == 0) {
+            assertNull(table.getBucketNum());
+        } else {
+            assertEquals(nbuckets, table.getBucketNum());
+        }
+    }
+
+    protected void assertNoResults(Connection conn, String cdcName) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            ResultSet rs = stmt.executeQuery("select * from " + cdcName);
+            assertFalse(rs.next());
+        }
     }
 
     protected Connection newConnection() throws SQLException {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCBaseIT.java
@@ -1,6 +1,5 @@
 package org.apache.phoenix.end2end;
 
-import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.query.QueryServicesOptions;
 import org.apache.phoenix.schema.PIndexState;
 import org.apache.phoenix.schema.PTable;
@@ -53,17 +52,17 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
         conn.createStatement().execute(table_sql + " " + String.join(", ", props));
     }
 
-    protected void createCDCAndWait(Connection conn, String tableName, String cdcName,
+    protected void createCDCAndWait(Connection conn, String schemaName, String tableName, String cdcName,
                                     String cdc_sql) throws Exception {
-        createCDCAndWait(conn, tableName, cdcName, cdc_sql, null, 0);
+        createCDCAndWait(conn, schemaName, tableName, cdcName, cdc_sql, null, 0);
     }
 
-    protected void createCDCAndWait(Connection conn, String tableName, String cdcName,
+    protected void createCDCAndWait(Connection conn, String schemaName, String tableName, String cdcName,
                                     String cdc_sql, PTable.QualifierEncodingScheme encodingScheme,
                                     int nSaltBuckets) throws Exception {
         // For CDC, multitenancy gets derived automatically via the parent table.
         createTable(conn, cdc_sql, encodingScheme, false, nSaltBuckets);
-        IndexToolIT.runIndexTool(false, null, tableName,
+        IndexToolIT.runIndexTool(false, schemaName, tableName,
                 "\""+CDCUtil.getCDCIndexName(cdcName)+"\"");
         TestUtil.waitForIndexState(conn, CDCUtil.getCDCIndexName(cdcName), PIndexState.ACTIVE);
     }
@@ -104,7 +103,7 @@ public class CDCBaseIT extends ParallelStatsDisabledIT {
         Properties props = new Properties();
         Connection conn = DriverManager.getConnection(getUrl(), props);
         PTable cdcTable = PhoenixRuntime.getTable(conn, cdcName);
-        assertEquals(nbuckets, cdcTable.getBucketNum());
+        assertNull(cdcTable.getBucketNum());
         PTable indexTable = PhoenixRuntime.getTable(conn, CDCUtil.getCDCIndexName(cdcName));
         assertEquals(nbuckets, indexTable.getBucketNum());
     }

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCDefinitionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCDefinitionIT.java
@@ -18,11 +18,11 @@
 package org.apache.phoenix.end2end;
 
 import org.apache.phoenix.exception.SQLExceptionCode;
-import org.apache.phoenix.hbase.index.IndexRegionObserver;
 import org.apache.phoenix.schema.PColumn;
 import org.apache.phoenix.schema.PTable;
 import org.apache.phoenix.util.CDCUtil;
 import org.apache.phoenix.util.PhoenixRuntime;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,10 +45,10 @@ import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 @Category(ParallelStatsDisabledTest.class)
-public class CDCMiscIT extends CDCBaseIT {
+public class CDCDefinitionIT extends CDCBaseIT {
     private final boolean forView;
 
-    public CDCMiscIT(boolean forView) {
+    public CDCDefinitionIT(boolean forView) {
         this.forView = forView;
     }
 
@@ -75,6 +75,7 @@ public class CDCMiscIT extends CDCBaseIT {
             tableName = viewName;
         }
         String cdcName = generateUniqueName();
+        String cdc_sql;
 
         try {
             conn.createStatement().execute("CREATE CDC " + cdcName
@@ -84,8 +85,8 @@ public class CDCMiscIT extends CDCBaseIT {
             assertEquals(SQLExceptionCode.TABLE_UNDEFINED.getErrorCode(), e.getErrorCode());
         }
 
-        String cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
-        createCDCAndWait(conn, tableName, cdcName, cdc_sql);
+        cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
+        createCDCAndWait(conn, null, tableName, cdcName, cdc_sql);
         assertCDCState(conn, cdcName, null, 3);
 
         try {
@@ -102,7 +103,7 @@ public class CDCMiscIT extends CDCBaseIT {
         cdcName = generateUniqueName();
         cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName +
                 " INCLUDE (pre, post) INDEX_TYPE=g";
-        createCDCAndWait(conn, tableName, cdcName, cdc_sql);
+        createCDCAndWait(conn, null, tableName, cdcName, cdc_sql);
         assertCDCState(conn, cdcName, "PRE,POST", 3);
         assertPTable(cdcName, new HashSet<>(
                 Arrays.asList(PTable.CDCChangeScope.PRE, PTable.CDCChangeScope.POST)), tableName,
@@ -110,7 +111,7 @@ public class CDCMiscIT extends CDCBaseIT {
 
         cdcName = generateUniqueName();
         cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName + " INDEX_TYPE=l";
-        createCDCAndWait(conn, tableName, cdcName, cdc_sql);
+        createCDCAndWait(conn, null, tableName, cdcName, cdc_sql);
         assertCDCState(conn, cdcName, null, 2);
         assertPTable(cdcName, null, tableName, datatableName);
 
@@ -118,11 +119,46 @@ public class CDCMiscIT extends CDCBaseIT {
         if (! forView) {
             cdcName = generateUniqueName();
             cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
-            createCDCAndWait(conn, tableName, cdcName, cdc_sql, null, 4);
+            createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, null, 4);
             assertSaltBuckets(cdcName, 4);
         }
 
         conn.close();
+    }
+
+    @Ignore // Timing out in IndexTool.
+    @Test
+    public void testCreateWithSchemaName() throws Exception {
+        Properties props = new Properties();
+        Connection conn = DriverManager.getConnection(getUrl(), props);
+        String schemaName = generateUniqueName();
+        String tableName = generateUniqueName();
+        String datatableName = tableName;
+        conn.createStatement().execute(
+                "CREATE TABLE  " + schemaName + "." + tableName + " ( k INTEGER PRIMARY KEY," +
+                        " v1 INTEGER, v2 DATE)");
+        if (forView) {
+            String viewName = generateUniqueName();
+            conn.createStatement().execute(
+                    "CREATE VIEW " + schemaName + "." + viewName + " AS SELECT * FROM " +
+                    schemaName + "."+ tableName);
+            tableName = viewName;
+        }
+        String cdcName = generateUniqueName();
+        String cdc_sql;
+
+        try {
+            conn.createStatement().execute("CREATE CDC " + cdcName
+                    + " ON NON_EXISTENT_TABLE");
+            fail("Expected to fail due to non-existent table");
+        } catch (SQLException e) {
+            assertEquals(SQLExceptionCode.TABLE_UNDEFINED.getErrorCode(), e.getErrorCode());
+        }
+
+        cdc_sql = "CREATE CDC " + cdcName + " ON " + schemaName + "." + tableName;
+        createCDCAndWait(conn, schemaName, tableName, cdcName, cdc_sql);
+        assertCDCState(conn, cdcName, null, 3);
+        assertPTable(cdcName, null, tableName, datatableName);
     }
 
     @Test
@@ -147,8 +183,7 @@ public class CDCMiscIT extends CDCBaseIT {
         assertEquals(true, cdcTable.isMultiTenant());
         List<PColumn> cdcPkColumns = cdcTable.getPKColumns();
         assertEquals("TENANTID", cdcPkColumns.get(0).getName().getString());
-        assertEquals("PHOENIX_ROW_TIMESTAMP()", cdcPkColumns.get(1).getName().getString());
-        assertEquals("K", cdcPkColumns.get(2).getName().getString());
+        assertEquals("K", cdcPkColumns.get(1).getName().getString());
     }
 
     @Test
@@ -172,8 +207,6 @@ public class CDCMiscIT extends CDCBaseIT {
                 String.valueOf(NON_ENCODED_QUALIFIERS.getSerializedMetadataValue()));
         PTable indexTable = PhoenixRuntime.getTable(conn, CDCUtil.getCDCIndexName(cdcName));
         assertEquals(indexTable.getEncodingScheme(), NON_ENCODED_QUALIFIERS);
-        PTable cdcTable = PhoenixRuntime.getTable(conn, cdcName);
-        assertEquals(cdcTable.getEncodingScheme(), NON_ENCODED_QUALIFIERS);
     }
 
     public void testDropCDC () throws SQLException {

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCDefinitionIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCDefinitionIT.java
@@ -276,7 +276,7 @@ public class CDCDefinitionIT extends CDCBaseIT {
         }
         String cdcName = generateUniqueName();
         String cdc_sql = "CREATE CDC  " + cdcName + " ON " + tableName;
-        conn.createStatement().execute(cdc_sql);
+        createCDCAndWait(conn, null, tableName, cdcName, cdc_sql);
         try {
             conn.createStatement().executeQuery("SELECT " +
                     "/*+ CDC_INCLUDE(DUMMY) */ * FROM " + cdcName);

--- a/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
+++ b/phoenix-core/src/it/java/org/apache/phoenix/end2end/CDCQueryIT.java
@@ -388,7 +388,7 @@ public class CDCQueryIT extends CDCBaseIT {
             cdcName = generateUniqueName();
             cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
             if (!dataFirst) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -446,7 +446,7 @@ public class CDCQueryIT extends CDCBaseIT {
         }
         if (dataFirst) {
             try (Connection conn = newConnection()) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -506,7 +506,7 @@ public class CDCQueryIT extends CDCBaseIT {
             cdcName = generateUniqueName();
             cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
             if (!dataFirst) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -577,7 +577,7 @@ public class CDCQueryIT extends CDCBaseIT {
 
         if (dataFirst) {
             try (Connection conn = newConnection()) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -650,7 +650,7 @@ public class CDCQueryIT extends CDCBaseIT {
             cdcName = generateUniqueName();
             cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
             if (!dataFirst) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
             conn.createStatement().execute("ALTER TABLE " + datatableName + " DROP COLUMN v0");
         }
@@ -696,7 +696,7 @@ public class CDCQueryIT extends CDCBaseIT {
 
         if (dataFirst) {
             try (Connection conn = newConnection()) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -770,7 +770,7 @@ public class CDCQueryIT extends CDCBaseIT {
             cdcName = generateUniqueName();
             cdc_sql = "CREATE CDC " + cdcName + " ON " + tableName;
             if (!dataFirst) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -794,7 +794,7 @@ public class CDCQueryIT extends CDCBaseIT {
 
         if (dataFirst) {
             try (Connection conn = newConnection()) {
-                createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+                createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
             }
         }
 
@@ -807,6 +807,11 @@ public class CDCQueryIT extends CDCBaseIT {
 
     @Test
     public void testSelectCDCFailDataTableUpdate() throws Exception {
+        if (dataFirst == true) {
+            // In this case, index will not exist at the time of upsert, so we can't simulate the
+            // index failure.
+            return;
+        }
         Connection conn = newConnection();
         String tableName = generateUniqueName();
         createTable(conn, "CREATE TABLE  " + tableName +
@@ -821,7 +826,7 @@ public class CDCQueryIT extends CDCBaseIT {
         String cdc_sql = "CREATE CDC " + cdcName
                 + " ON " + tableName;
         if (! dataFirst) {
-            createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+            createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
         }
         IndexRegionObserver.setFailDataTableUpdatesForTesting(true);
         EnvironmentEdgeManager.injectEdge(injectEdge);
@@ -870,7 +875,7 @@ public class CDCQueryIT extends CDCBaseIT {
         EnvironmentEdgeManager.reset();
 
         if (dataFirst) {
-            createCDCAndWait(conn, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
+            createCDCAndWait(conn, null, tableName, cdcName, cdc_sql, encodingScheme, nSaltBuckets);
         }
 
         ResultSet rs = conn.createStatement().executeQuery("SELECT * FROM " + cdcName);

--- a/phoenix-core/src/main/java/org/apache/phoenix/compile/CreateIndexCompiler.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/compile/CreateIndexCompiler.java
@@ -260,7 +260,7 @@ public class CreateIndexCompiler {
         return new BaseMutationPlan(context, operation) {
             @Override
             public MutationState execute() throws SQLException {
-                return client.createIndex(create, splits, null);
+                return client.createIndex(create, splits);
             }
 
             @Override

--- a/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/schema/MetaDataClient.java
@@ -1435,11 +1435,10 @@ public class MetaDataClient {
      *    listed as an index column.
      * @param statement
      * @param splits
-     * @param indexPKExpresionsType If non-{@code null}, all PK expressions should be of this specific type.
      * @return MutationState from population of index table from data table
      * @throws SQLException
      */
-    public MutationState createIndex(CreateIndexStatement statement, byte[][] splits, PDataType indexPKExpresionsType) throws SQLException {
+    public MutationState createIndex(CreateIndexStatement statement, byte[][] splits) throws SQLException {
         IndexKeyConstraint ik = statement.getIndexConstraint();
         TableName indexTableName = statement.getIndexTableName();
 
@@ -1553,9 +1552,6 @@ public class MetaDataClient {
                 }
                 if (expression.isStateless()) {
                     throw new SQLExceptionInfo.Builder(SQLExceptionCode.STATELESS_EXPRESSION_NOT_ALLOWED_IN_INDEX).build().buildException();
-                }
-                if (indexPKExpresionsType != null && expression.getDataType() != indexPKExpresionsType) {
-                    throw new SQLExceptionInfo.Builder(SQLExceptionCode.INCORRECT_DATATYPE_FOR_EXPRESSION).build().buildException();
                 }
                 unusedPkColumns.remove(expression);
 
@@ -1741,30 +1737,27 @@ public class MetaDataClient {
                 statement.getProps().size() + 1);
         populatePropertyMaps(statement.getProps(), tableProps, commonFamilyProps, PTableType.CDC);
 
-        NamedNode indexName = FACTORY.indexName(CDCUtil.getCDCIndexName(
-                statement.getCdcObjName().getName()));
-        IndexKeyConstraint indexKeyConstraint =
-                FACTORY.indexKey(Arrays.asList(new Pair[]{Pair.newPair(
-                        FACTORY.function(PhoenixRowTimestampFunction.NAME, Collections.emptyList()),
-                        SortOrder.getDefault())}));
         IndexType indexType = (IndexType) TableProperty.INDEX_TYPE.getValue(tableProps);
-        ListMultimap<String, Pair<String, Object>> indexProps = ArrayListMultimap.create();
-        // Transfer properties to index and let create index recognize those that are relevant,
-        // (e.g. SALT_BUCKETS and COLUMN_ENCODED_BYTES) and let the others get ignored.
-        for (Map.Entry<String, Object> propSet: tableProps.entrySet()) {
-            indexProps.put(QueryConstants.ALL_FAMILY_PROPERTIES_KEY, new Pair<>(propSet.getKey(),
-                    propSet.getValue()));
+        PhoenixStatement pstmt = new PhoenixStatement(connection);
+        String dataTableFullName = SchemaUtil.getTableName(statement.getDataTable().getSchemaName(),
+                statement.getDataTable().getTableName());
+        String createIndexSql = "CREATE " +
+                (indexType == IndexType.LOCAL ? "LOCAL " : "UNCOVERED ") +
+                "INDEX " + (statement.isIfNotExists() ? "IF NOT EXISTS " : "") +
+                "\"" + CDCUtil.getCDCIndexName(statement.getCdcObjName().getName()) + "\"" +
+                " ON " + dataTableFullName + " (" + PhoenixRowTimestampFunction.NAME + "()) ASYNC";
+        List<String> indexProps = new ArrayList<>();
+        Object saltBucketNum = TableProperty.SALT_BUCKETS.getValue(tableProps);
+        if (saltBucketNum != null) {
+            indexProps.add("SALT_BUCKETS=" + saltBucketNum);
         }
-        CreateIndexStatement indexStatement = FACTORY.createIndex(indexName, FACTORY.namedTable(null,
-                        statement.getDataTable(), (Double) null), indexKeyConstraint, null, null,
-                        indexProps, statement.isIfNotExists(), indexType, true, 0,
-                        new HashMap<>(), null);
-        MutationState indexMutationState;
+        Object columnEncodedBytes = TableProperty.COLUMN_ENCODED_BYTES.getValue(tableProps);
+        if (columnEncodedBytes != null) {
+            indexProps.add("COLUMN_ENCODED_BYTES=" + columnEncodedBytes);
+        }
+        createIndexSql = createIndexSql + " " + String.join(", ", indexProps);
         try {
-            // TODO: Should we also allow PTimestamp here, in fact PTimestamp is the right type,
-            // but we are forced to support PDate because of incorrect type for
-            // PHOENIX_ROW_TIMESTAMP (see PHOENIX-6807)?
-            indexMutationState = createIndex(indexStatement, null, PDate.INSTANCE);
+            pstmt.execute(createIndexSql);
         } catch (SQLException e) {
             if (e.getErrorCode() == TABLE_ALREADY_EXIST.getErrorCode()) {
                 throw new SQLExceptionInfo.Builder(TABLE_ALREADY_EXIST).setTableName(
@@ -1800,7 +1793,7 @@ public class MetaDataClient {
         createTableInternal(tableStatement, null, dataTable, null, null, null,
                 null, null, false, null,
                 null, statement.getIncludeScopes(), tableProps, commonFamilyProps);
-        return indexMutationState;
+        return new MutationState(0, 0, connection);
     }
 
     /**
@@ -2025,7 +2018,7 @@ public class MetaDataClient {
         }
         return false;
     }
-    
+
     /**
      * While adding or dropping columns we write a cell to the SYSTEM.MUTEX table with the rowkey of the
      * physical table to prevent conflicting concurrent modifications. For eg two client adding a column
@@ -2413,8 +2406,8 @@ public class MetaDataClient {
                 .setSchemaName(schemaName).setTableName(tableName)
                 .build().buildException();
             }
-            if (TableProperty.TTL.getValue(commonFamilyProps) != null 
-                    && transactionProvider != null 
+            if (TableProperty.TTL.getValue(commonFamilyProps) != null
+                    && transactionProvider != null
                     && transactionProvider.getTransactionProvider().isUnsupported(PhoenixTransactionProvider.Feature.SET_TTL)) {
                 throw new SQLExceptionInfo.Builder(PhoenixTransactionProvider.Feature.SET_TTL.getCode())
                 .setMessage(transactionProvider.name())
@@ -2544,7 +2537,7 @@ public class MetaDataClient {
                     }
                     pkColumns = newLinkedHashSet(parent.getPKColumns());
 
-                    // Add row linking view to its parent 
+                    // Add row linking view to its parent
                     try (PreparedStatement linkStatement = connection.prepareStatement(CREATE_VIEW_LINK)) {
                         linkStatement.setString(1, tenantIdStr);
                         linkStatement.setString(2, schemaName);
@@ -2643,7 +2636,7 @@ public class MetaDataClient {
                 /*
                  * We can't control what column qualifiers are used in HTable mapped to Phoenix views. So we are not
                  * able to encode column names.
-                 */  
+                 */
                 if (viewType != MAPPED) {
                     /*
                      * For regular phoenix views, use the storage scheme of the physical table since they all share the
@@ -2661,14 +2654,14 @@ public class MetaDataClient {
             // System tables have hard-coded column qualifiers. So we can't use column encoding for them.
             else if (!SchemaUtil.isSystemTable(Bytes.toBytes(SchemaUtil.getTableName(schemaName, tableName)))|| SchemaUtil.isLogTable(schemaName, tableName)) {
                 /*
-                 * Indexes inherit the storage scheme of the parent data tables. Otherwise, we always attempt to 
-                 * create tables with encoded column names. 
-                 * 
-                 * Also of note is the case with shared indexes i.e. local indexes and view indexes. In these cases, 
-                 * column qualifiers for covered columns don't have to be unique because rows of the logical indexes are 
+                 * Indexes inherit the storage scheme of the parent data tables. Otherwise, we always attempt to
+                 * create tables with encoded column names.
+                 *
+                 * Also of note is the case with shared indexes i.e. local indexes and view indexes. In these cases,
+                 * column qualifiers for covered columns don't have to be unique because rows of the logical indexes are
                  * partitioned by the virtue of indexId present in the row key. As such, different shared indexes can use
                  * potentially overlapping column qualifiers.
-                 * 
+                 *
                  */
                 if (parent != null) {
                     Byte encodingSchemeSerializedByte = (Byte) TableProperty.COLUMN_ENCODED_BYTES.getValue(tableProps);
@@ -2916,7 +2909,7 @@ public class MetaDataClient {
                         column.getFamilyName());
                 }
             }
-            
+
             // We need a PK definition for a TABLE or mapped VIEW
             if (!wasPKDefined && pkColumnsNames.isEmpty() && tableType != PTableType.VIEW && viewType != ViewType.MAPPED) {
                 throw new SQLExceptionInfo.Builder(SQLExceptionCode.PRIMARY_KEY_MISSING)
@@ -3008,7 +3001,7 @@ public class MetaDataClient {
                         .build();
                 connection.addTable(table, MetaDataProtocol.MIN_TABLE_TIMESTAMP);
             }
-            
+
             // Update column qualifier counters
             if (EncodedColumnsUtil.usesEncodedColumnNames(encodingScheme)) {
                 // Store the encoded column counter for phoenix entities that have their own hbase

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/CDCUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/CDCUtil.java
@@ -83,12 +83,7 @@ public class CDCUtil {
     }
 
     public static String getCDCIndexName(String cdcName) {
-        return CDC_INDEX_PREFIX + cdcName;
-    }
-
-    public static String getCDCNameFromIndexName(String indexName) {
-        assert(indexName.startsWith(CDC_INDEX_PREFIX));
-        return indexName.substring(CDC_INDEX_PREFIX.length());
+        return CDC_INDEX_PREFIX + cdcName.toUpperCase();
     }
 
     public static boolean isCDCIndex(String indexName) {


### PR DESCRIPTION
* Rework the CDC index creation logic so that index gets presplit per salt_buckets
* All the prior tests are now green, but the new tests for salting on data table are not passing
* More refactoring to remvoe duplication and cruft.